### PR TITLE
Don't remove badgeLabel if it's not visible

### DIFF
--- a/ENMBadgedBarButtonItem.swift
+++ b/ENMBadgedBarButtonItem.swift
@@ -21,7 +21,9 @@ class ENMBadgedBarButtonItem: UIBarButtonItem {
     var badgeValue: String {
         didSet {
             guard !shouldBadgeHide(badgeValue) else {
-                removeBadge()
+                if (badgeLabel.superview != nil) {
+                    removeBadge()
+                }
                 return
             }
             


### PR DESCRIPTION
When the badgeLabel is not visible, let's not remove if, because if the value is rapidly changed it will remain hidden.