### PR TITLE
Update to resolve Swift 4 conflicts

### DIFF
--- a/SampleApp-Swift/BadgedBarButtonItem/BadgedBarButtonItem.swift
+++ b/SampleApp-Swift/BadgedBarButtonItem/BadgedBarButtonItem.swift
@@ -73,7 +73,7 @@ open class BadgedBarButtonItem: UIBarButtonItem {
     */
     public var badgeProperties: BadgeProperties
     
-    public init(customView: UIView, value: Int, badgeProperties: BadgeProperties = BadgeProperties.default) {
+    public init(customView: UIView, value: Int, badgeProperties: BadgeProperties = BadgeProperties()) {
         self.badgeProperties = badgeProperties
         super.init()
         
@@ -87,7 +87,7 @@ open class BadgedBarButtonItem: UIBarButtonItem {
                 frame: CGRect,
                 title: String? = nil,
                 image: UIImage?,
-                badgeProperties: BadgeProperties = BadgeProperties.default) {
+                badgeProperties: BadgeProperties = BadgeProperties()) {
         
         self.badgeProperties = badgeProperties
         super.init()
@@ -97,7 +97,7 @@ open class BadgedBarButtonItem: UIBarButtonItem {
     }
     
     public required init?(coder aDecoder: NSCoder) {
-        self.badgeProperties = BadgeProperties.default
+        self.badgeProperties = BadgeProperties()
         super.init(coder: aDecoder)
         
         var buttonFrame: CGRect = CGRect.zero

--- a/SampleApp-Swift/BadgedBarButtonItem/BadgedBarItemProperties.swift
+++ b/SampleApp-Swift/BadgedBarButtonItem/BadgedBarItemProperties.swift
@@ -38,10 +38,6 @@ public class BadgeProperties {
     public var textColor: UIColor
     public var backgroundColor: UIColor
     
-    /**
-     A quick way to instantiate badge properties with their default values.
-    */
-    static let `default` = BadgeProperties()
     
     public init(
         originalFrame: CGRect = CGRect.zero,


### PR DESCRIPTION
I removed the 'default' static var because Swift 4 didn't like it. I think it's simpler to just use the init everywhere anyways. This also doesn't affect anything on Swift 3.