### PR TITLE
Update BadgedBarButtonItem.swift

### DIFF
--- a/SampleApp-Swift/BadgedBarButtonItem/BadgedBarButtonItem.swift
+++ b/SampleApp-Swift/BadgedBarButtonItem/BadgedBarButtonItem.swift
@@ -225,6 +225,11 @@ fileprivate extension BadgedBarButtonItem {
     func removeBadge() {
         let duration = shouldAnimateBadge ? 0.08 : 0.0
         
+        CATransaction.begin()
+        CATransaction.setCompletionBlock({
+            self.badgeLabel.removeFromSuperview()
+        })
+
         let currentTransform = badgeLabel.layer.transform
         let tf = CATransform3DMakeScale(0.001, 0.001, 1.0)
         badgeLabel.layer.transform = tf


### PR DESCRIPTION
Fixes missing opacity and frame when badge was "removed".

When a badge is removed (opacity is animated to zero) the opacity is net resetted to 1 and the frame is not correct, because it never gets removed from it's superview and therefore animateBadgeValueUpdate() is called in this case. 